### PR TITLE
Add a new option `target_version` while allows you to set your python verion (analogous to `--target-version`)

### DIFF
--- a/doc/black.md
+++ b/doc/black.md
@@ -27,7 +27,8 @@ For example:
 ```vim
 let g:black#settings = {
     \ 'fast': 1,
-    \ 'line_length': 100
+    \ 'line_length': 100,
+    \ 'target_version': 'py310'
 \}
 ```
 
@@ -35,3 +36,6 @@ let g:black#settings = {
   Set to a non-zero number to skip the AST check. This makes formatting a lot faster.
 - `line_length` (default: 88)
   Set to an integer to tell Black where to wrap lines.
+- `target_version` (default: '')
+  Sets the `--target-version` flag in the commandline. Useful if you use the new match
+  syntax, as Black can only handle it when you set the version to 3.10 or above.

--- a/doc/black.txt
+++ b/doc/black.txt
@@ -29,7 +29,8 @@ For example:
 >
     let g:black#settings = {
         \ 'fast': 1,
-        \ 'line_length': 100
+        \ 'line_length': 100,
+        \ 'target_version': 'py310'
     \}
 <
 * `fast` (default: 0)
@@ -37,5 +38,8 @@ For example:
   faster.
 * `line_length` (default: 88)
   Set to an integer to tell Black where to wrap lines.
+* `target_version` (default: '')
+  Sets the `--target-version` flag in the commandline. Useful if you use the new match
+  syntax, as Black can only handle it when you set the version to 3.10 or above.
 
 vim:ft=help:tw=80:ts=4:et:

--- a/rplugin/python3/blacken.py
+++ b/rplugin/python3/blacken.py
@@ -3,12 +3,13 @@
 
 import time
 import sys
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Set
 
 import pynvim
 
 try:
     import black
+    from black import TargetVersion
 except ImportError:
     print(
         "[*] Black is not installed in your g:python3_host_prog, "
@@ -25,7 +26,7 @@ class Blacken:
 
     @pynvim.function("Black")
     # args is not used but needs to be there to avoid an error.
-    def black(self, args: List[str]) -> None:
+    def black_(self, args: List[str]) -> None:
         if self.n.current.buffer.options.get("filetype") != "python":
             self.n.err_write("Not in a python file.\n")
             return
@@ -37,23 +38,60 @@ class Blacken:
 
     @pynvim.function("BlackSync", sync=True)
     def blacksync(self, args: List[str]) -> None:
-        return self.black(args)
+        return self.black_(args)
 
-    def get_opts(self) -> Dict[str, Union[int, bool]]:
+    def get_opts(self) -> Dict[str, Union[int, bool, str]]:
         options = {
             "fast": False,
             "line_length": 88,
             "is_pyi": self.n.current.buffer.name.endswith(".pyi"),
+            "target_version": "",
         }
         user_options = self.n.vars.get("black#settings")
         if user_options is not None:
             options.update(user_options)
         return options
 
+    def parse_target_version(self, target_version: str) -> Set[black.TargetVersion]:
+        self.n.err_write(repr(black))
+        if target_version.lower() == "":
+            return set()
+        elif target_version.lower() == "py33":
+            return {black.TargetVersion.PY33}
+        elif target_version.lower() == "py34":
+            return {black.TargetVersion.PY34}
+        elif target_version.lower() == "py35":
+            return {black.TargetVersion.PY35}
+        elif target_version.lower() == "py36":
+            return {black.TargetVersion.PY36}
+        elif target_version.lower() == "py37":
+            return {black.TargetVersion.PY37}
+        elif target_version.lower() == "py38":
+            return {black.TargetVersion.PY38}
+        elif target_version.lower() == "py39":
+            return {black.TargetVersion.PY39}
+        elif target_version.lower() == "py310":
+            return {black.TargetVersion.PY310}
+        elif target_version.lower() == "py311":
+            return {black.TargetVersion.PY311}
+        else:
+            self.n.err_write(
+                f"{target_version!r} is an invalid target_version. "
+                "Use 'py38' for python 3.8 for example.\n"
+            )
+            return set()
+
     def format_buff(
-        self, to_format: str, opts: Dict[str, Union[int, bool]], start: float
+        self,
+        to_format: str,
+        opts: Dict[str, Union[int, bool, str]],
+        start: float,
     ) -> None:
-        mode = black.FileMode(line_length=opts["line_length"], is_pyi=opts["is_pyi"])
+        mode = black.FileMode(
+            line_length=opts["line_length"],
+            is_pyi=opts["is_pyi"],
+            target_versions=self.parse_target_version(opts["target_version"]),
+        )
         try:
             new_buffer = black.format_file_contents(
                 to_format, fast=opts["fast"], mode=mode


### PR DESCRIPTION
To support the new match..case syntax you need to instruct black to use a newer python version. This is done with `--target-version` (as mentioned [here](https://github.com/psf/black/issues/2242)). This PR adds support for this option in the settings dict.